### PR TITLE
[webhooks] add flask example link

### DIFF
--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -248,6 +248,7 @@ Remember to adhere to best practices for security and perform thorough testing t
 
 ## Examples 💡
 
-- [FastAPI webhook processor](https://github.com/android-sms-gateway/example-webhooks-fastapi): Demonstrates registration, HMAC validation, and payload handling.
+- [Flask webhook processor](https://github.com/android-sms-gateway/example-webhooks-flask): Demonstrates registration, HMAC validation, and payload handling with Flask.
+- [FastAPI webhook processor](https://github.com/android-sms-gateway/example-webhooks-fastapi): Demonstrates registration, HMAC validation, and payload handling with FastAPI.
 - [Telegram Forwarder Function](https://github.com/android-sms-gateway/example-telegram-forwarder-fn): Forwards SMS to Telegram using a cloud function.
 - [Web Client](https://github.com/android-sms-gateway/web-client-ts): Node.js client for sending/receiving SMS via Socket.io.

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -6,6 +6,7 @@ In this section, you will find links to examples related to this project. We do 
 
 ### Official Examples
 
+- [Flask webhook processor](https://github.com/android-sms-gateway/example-webhooks-flask) - A Flask app that demonstrates registration, HMAC validation, and payload handling.
 - [FastAPI webhook processor](https://github.com/android-sms-gateway/example-webhooks-fastapi) - A FastAPI app that demonstrates registration, HMAC validation, and payload handling.
 - [Discord Forwarder Function](https://github.com/android-sms-gateway/example-discord-forwarder-fn) - A Cloud Function to seamlessly forward SMS messages to a Discord server using webhooks.
 - [Telegram Forwarder Function](https://github.com/android-sms-gateway/example-telegram-forwarder-fn) - A Cloud Function to seamlessly forward SMS messages to a Telegram chat using webhooks.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new example link for a "Webhook Processor (Flask)" application to the webhooks and examples documentation, demonstrating registration, HMAC validation, and payload handling.
  - Updated the existing FastAPI webhook processor example to clarify its features and repositioned it after the new Flask example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->