### PR TITLE
[webhooks] add by device registration sections

### DIFF
--- a/docs/faq/webhooks.md
+++ b/docs/faq/webhooks.md
@@ -63,6 +63,19 @@ By default, webhooks require internet access and will wait until it's available 
     Disabling internet access requirement may affect the reliability of webhook delivery for external endpoints
 
 
+### How to manage webhooks for specific devices? :material-cellphone-link:
+
+1. Get device ID from API response when listing devices
+2. Include `device_id` parameter when registering webhooks:
+   ```json
+   {
+     "url": "https://your-server.com/webhooks",
+     "event": "sms:received",
+     "device_id": "MxKw03Q2ZVoomrLeDLlMO"
+   }
+   ```
+3. Webhooks without `device_id` will apply to all devices
+
 ## Still Having Issues? :material-chat-question:
 
 Visit our [Support Forum](https://github.com/capcom6/android-sms-gateway/discussions) :material-forum: or contact us at [support@sms-gate.app](mailto:support@sms-gate.app) :material-email:

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -80,6 +80,16 @@ In Cloud and Private modes, please allow some time for the webhooks list to sync
 !!! note "Multiple Events"
     Each webhook is registered for a single event. To listen for multiple events, register separate webhooks.
 
+!!! tip "Device-Specific Webhooks"
+    To register a webhook for a specific device, include the `device_id` parameter in the API request. If the `device_id` is not provided, the webhook will be applied to all devices associated with the account.
+
+    ```sh title="Cloud mode example"
+    curl -X POST -u <username>:<password> \
+    -H "Content-Type: application/json" \
+    -d '{ "url": "https://your-server.com/webhook", "event": "sms:received", "device_id": "DEVICE_ID" }' \
+    https://api.sms-gate.app/3rdparty/v1/webhooks
+    ```
+
 ### Step 3: Verify Your Webhook ✔️
 
 === "Via API Method :material-api:"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed instructions in the FAQ and features sections on how to register webhooks for specific devices using a device ID.
  - Included examples and clarifications on targeting individual devices versus all devices when setting up webhooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->