### PR TITLE
[migration] migrate to use `textMessage` field instead of `message`

### DIFF
--- a/docs/faq/errors.md
+++ b/docs/faq/errors.md
@@ -69,7 +69,7 @@ The `RESULT_NO_DEFAULT_SMS_APP` error occurs when no default SMS app is set on t
 
     ```json title="Explicit SIM Specification" hl_lines="4"
     {
-        "message": "Test",
+        "textMessage": { "text": "Test"},
         "phoneNumbers": ["+1234567890"],
         "simNumber": 1
     }

--- a/docs/faq/general.md
+++ b/docs/faq/general.md
@@ -66,7 +66,7 @@ Please refer to the [Multi-SIM Support](../features/multi-sim.md) section.
 
 ```json title="Disable Delivery Reports"
 {
-  "message": "Your OTP: 1234",
+  "textMessage": { "text": "Your OTP: 1234"},
   "phoneNumbers": ["+1234567890"],
   "withDeliveryReport": false // (1)!
 }

--- a/docs/features/multi-sim.md
+++ b/docs/features/multi-sim.md
@@ -16,7 +16,7 @@ curl -X POST \
     -H 'Content-Type: application/json' \
     https://api.sms-gate.app/3rdparty/v1/message \
     -d '{
-        "message": "Hello from SIM2, Dr. Turk!",
+        "textMessage": { "text": "Hello from SIM2, Dr. Turk!"},
         "phoneNumbers": ["+19162255887"],
         "simNumber": 2
     }'

--- a/docs/getting-started/local-server.md
+++ b/docs/getting-started/local-server.md
@@ -20,7 +20,7 @@ This mode is ideal for sending messages from a local network.
     ```sh
     curl -X POST -u <username>:<password> \
         -H "Content-Type: application/json" \
-        -d '{ "message": "Hello, world!", "phoneNumbers": ["+79990001234", "+79995556677"] }' \
+        -d '{ "textMessage": { "text": "Hello, world!"}, "phoneNumbers": ["+79990001234", "+79995556677"] }' \
         http://<device_local_ip>:8080/message
     ```
 

--- a/docs/getting-started/public-cloud-server.md
+++ b/docs/getting-started/public-cloud-server.md
@@ -96,8 +96,7 @@ sequenceDiagram
     === "cURL"
         ```bash
         curl -X POST -u "username:password" \
-         -H "Content-Type: application/json" \
-         -d '{"message":"Hello World","phoneNumbers":["+79990001234"]}' \
+         --json '{"textMessage":{"text":"Hello World"},"phoneNumbers":["+19162255887"]}' \
          https://api.sms-gate.app/3rdparty/v1/messages
         ```
 
@@ -109,8 +108,8 @@ sequenceDiagram
             "https://api.sms-gate.app/3rdparty/v1/messages",
             auth=("username", "password"),
             json={
-                "message": "Hello World",
-                "phoneNumbers": ["+79990001234"]
+                "textMessage": { "text": "Hello World"},
+                "phoneNumbers": ["+19162255887"]
             }
         )
         ```
@@ -124,7 +123,7 @@ sequenceDiagram
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({
-            message: "Hello World",
+            textMessage: { text: "Hello World" },
             phoneNumbers: ["+79990001234"]
           })
         });

--- a/docs/getting-started/webhooks.md
+++ b/docs/getting-started/webhooks.md
@@ -25,7 +25,7 @@ Follow these steps to set up webhooks:
       "event": "sms:received",
       "id": "Ey6ECgOkVVFjz3CL48B8C",
       "payload": {
-        "message": "Android is always a sweet treat!",
+        "textMessage": { "text": "Android is always a sweet treat!"},
         "phoneNumber": "6505551212",
         "receivedAt": "2024-06-22T15:46:11.000+07:00"
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all relevant examples and code snippets to use a nested "textMessage" object with a "text" field for SMS content, replacing the previous top-level "message" string format.
  * Refreshed sample API requests, webhook payloads, and FAQ entries to reflect the new message payload structure.
  * Adjusted some example phone numbers and improved command syntax in code samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->