### PR TITLE
[faq] add delivery reports case to the generic failure error

### DIFF
--- a/docs/faq/errors.md
+++ b/docs/faq/errors.md
@@ -21,11 +21,12 @@ The app requires the `android.permission.SEND_SMS` permission to send SMS messag
 The `RESULT_ERROR_GENERIC_FAILURE` error can occur for various reasons:
 
 - :money_with_wings: **Low Balance**: Check SIM balance
-- :material-signal-off: **Network Issues**: Verify signal bars, try airplane mode toggle  
+- :material-signal-off: **Network Issues**: Verify signal bars, try airplane mode toggle
 - :material-sim-off: **SIM Problems**:
     - Reinsert SIM card.
     - Test in different device.
     - Contact carrier for activation status.
+- 📋 **Delivery Reports**: Try to disable delivery reports by adding `"withDeliveryReport": false` to your request.
 
 ## `RESULT_ERROR_LIMIT_EXCEEDED` Error 🚫
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the FAQ with a new troubleshooting tip for the `RESULT_ERROR_GENERIC_FAILURE` error, suggesting that disabling delivery reports may help resolve the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->