### PR TITLE
[webhooks] replace custom build with insecure

### DIFF
--- a/docs/faq/webhooks.md
+++ b/docs/faq/webhooks.md
@@ -52,6 +52,9 @@ Due to Android OS security requirements and the app's privacy policy, webhook ev
     3. **Secure Tunnels**
         Services like [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/) or [ngrok](https://ngrok.com/) provide HTTPS endpoints for local servers
 
+    4. **Insecure Build Variant** (Not Recommended)  
+       For local development and testing, use the [insecure build variant](#using-http-webhooks-in-local-development) that allows communication over HTTP without SSL.
+
 ??? note "Security Rationale"
     This requirement balances:
 

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -208,15 +208,15 @@ For webhooks within private networks:
 2. **ADB Port Forwarding**  
    Use `127.0.0.1` with reverse port forwarding:
    ```bash
-   adb reverse tcp:9876 tcp:8080 
+   adb reverse tcp:9876 tcp:8080
    ```
    Then register webhook to `http://127.0.0.1:9876/webhook`
 
 3. **Secure Tunnels**  
    Services like [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/) or [ngrok](https://ngrok.com/) provide HTTPS endpoints
 
-4. **Custom Build** (Advanced)  
-   [Rebuild the app](https://github.com/capcom6/android-sms-gateway/) with cleartext enabled - see [FAQ](../faq/webhooks.md#alternative-testing-approaches)
+4. **Insecure Build Variant** (Not Recommended)  
+   For local development and testing, use the [insecure build variant](../faq/webhooks.md#using-http-webhooks-in-local-development) that allows communication over HTTP without SSL.
 
 ## Security Considerations 🔐
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added “Insecure Build Variant (Not Recommended)” as a local development option for HTTP webhooks, with clear guidance and cross-links to the relevant FAQ section.
  - Updated features page to reflect the new option in the local network solutions list and adjusted references accordingly.
  - Clarified that the insecure variant is for local/testing use only, not production.
  - Performed minor formatting cleanup (removed trailing space) in the ADB port-forwarding command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->