### PR TITLE
[services] add SMPP server docs

### DIFF
--- a/docs/blog/posts/2026-05-smpp-server-introduction.md
+++ b/docs/blog/posts/2026-05-smpp-server-introduction.md
@@ -1,0 +1,103 @@
+---
+title: "Introducing SMPP Server: Telecom-Grade SMS Integration for SMSGate"
+date: 2026-05-20
+categories:
+  - Integration
+  - SMPP
+  - Infrastructure
+description: "Learn about the new SMPP Server for SMS Gateway — a standalone SMPP v3.4 service that bridges telecom-grade messaging platforms with Android devices."
+author: SMSGate Team LLM / Big Pickle
+---
+
+# 📡 Introducing SMPP Server: Telecom-Grade SMS Integration for SMSGate
+
+We're excited to announce the **SMPP Server** — a new standalone service that brings SMPP v3.4 protocol support to the SMSGate ecosystem. This enables SMS aggregators, messaging platforms, and any SMPP-compatible client to send and receive SMS messages through Android devices running the SMS Gateway app.
+
+<!-- more -->
+
+## 🎯 Why SMPP?
+
+SMPP (Short Message Peer-to-Peer) is the telecommunications industry standard for exchanging SMS messages. It has been the backbone of enterprise messaging for decades, used by:
+
+- **SMS aggregators** connecting to multiple carriers
+- **Messaging platforms** managing high-volume throughput
+- **Enterprise systems** requiring standardized telecom integration
+- **Legacy infrastructure** built around SMPP protocol
+
+Until now, integrating with SMSGate required using the REST API. While the REST API is powerful and flexible, many organizations already have SMPP-based systems in place. The SMPP Server bridges this gap.
+
+## 🏗️ How It Works
+
+The SMPP Server acts as a translator between the SMPP protocol and the SMS Gateway REST API:
+
+```
+SMS Aggregator (ESME Client)
+         │
+         │ SMPP v3.4 (port 2775/2776)
+         ▼
+   [SMPP Server]  ← Standalone Go service
+         │
+         │ HTTP REST API
+         ▼
+   [SMS Gateway REST API]
+         │
+         ▼
+   [Android Devices]
+```
+
+When an SMPP client connects and authenticates using its SMS Gateway credentials:
+
+1. The SMPP Server validates credentials via the Gateway API (Basic Auth → JWT)
+2. For receiver/transceiver sessions, a dynamic webhook is registered for delivery receipts
+3. `SUBMIT_SM` PDUs are translated into HTTP API calls to send SMS
+4. `QUERY_SM` PDUs check message status through the Gateway API
+5. Delivery status updates arrive via webhooks (DELIVER_SM forwarding coming soon)
+
+## ✨ Key Features
+
+- **Full SMPP v3.4 support** — BIND, SUBMIT_SM, QUERY_SM, UNBIND, ENQUIRE_LINK
+- **Session management** — Thread-safe state machine with TX/RX/TRX bind types
+- **TLS encryption** — SMPPs support on port 2776
+- **Dynamic webhooks** — Automatic webhook registration per session for delivery receipts
+- **Error mapping** — Comprehensive HTTP-to-SMPP error code translation (36+ codes)
+- **Standalone deployment** — No shared database, deploy anywhere with network access to the Gateway API
+
+## 🚀 Getting Started
+
+The SMPP Server is available as pre-built binaries, Docker images, or can be built from source:
+
+```bash title="Quick Start with Docker"
+docker run \
+  -p 2775:2775 \
+  -e SMPP__BIND_ADDRESS=0.0.0.0:2775 \
+  -e GATEWAY__API_BASE_URL=https://api.sms-gate.app/3rdparty/v1 \
+  -e GATEWAY__WEBHOOK_BASE_URL=https://your-public-url \
+  ghcr.io/android-sms-gateway/smpp-server:latest
+```
+
+Connect your SMPP client to `localhost:2775` using your SMS Gateway username and password as the `system_id` and `password` in the BIND PDU.
+
+## 📖 Documentation
+
+Comprehensive documentation is available in the docs:
+
+- **[SMPP Server Guide](../../services/smpp-server.md)** — Installation, configuration, deployment
+- **[SMPP Protocol Integration](../../integration/smpp.md)** — Protocol details, parameter mapping, error codes
+- **[SMPP FAQ](../../faq/smpp-server.md)** — Troubleshooting and technical questions
+
+## 🔮 What's Next
+
+The SMPP Server is actively developed. Here's what's on the roadmap:
+
+- ✅ SMPP v3.4 protocol support
+- ✅ TLS/SMPPs support
+- ✅ Dynamic webhook registration
+- 🔄 DELIVER_SM delivery receipt forwarding (in progress)
+- 📋 Prometheus metrics
+- 🔧 Rate limiting per client
+- 📨 Multi-part SMS concatenation
+- 🔤 UCS2/binary message support
+
+## 💬 Feedback
+
+We'd love to hear your feedback! If you encounter any issues or have feature requests, please open an issue on the [SMPP Server GitHub repository](https://github.com/android-sms-gateway/smpp-server).

--- a/docs/faq/smpp-server.md
+++ b/docs/faq/smpp-server.md
@@ -1,0 +1,96 @@
+# 📡 SMPP Server
+
+## 📋 General
+
+### What is SMPP?
+
+SMPP (Short Message Peer-to-Peer) is a telecommunications industry protocol used for exchanging SMS messages between external messaging entities (ESME) and Short Message Service Centers (SMSC). It is widely used by SMS aggregators, messaging platforms, and enterprise communication systems.
+
+### When should I use SMPP vs the REST API?
+
+Use **SMPP** when:
+
+- You have existing SMPP-based infrastructure or SMS aggregator integrations
+- You need to work with telecom-grade messaging platforms
+- Your organization requires SMPP protocol compliance
+- You want standardized session management with bind/unbind lifecycle
+
+Use the **[REST API](../integration/api.md)** when:
+
+- You are building a new integration from scratch
+- You need access to all SMSGate features (MMS, data SMS, scheduling, etc.)
+- You prefer HTTP-based integrations with JSON payloads
+- You want simpler setup without SMPP protocol overhead
+
+### Is the SMPP Server part of the main SMSGate project?
+
+No. The SMPP Server is a **separate standalone service** ([GitHub Repository](https://github.com/android-sms-gateway/smpp-server)) that communicates with the SMSGate via its REST API. It does not share a database and can be deployed independently.
+
+## 🔧 Troubleshooting
+
+### I can't connect to the SMPP Server
+
+Check the following:
+
+1. **Bind address**: By default, the server binds to `127.0.0.1:2775`. For remote access, set `SMPP__BIND_ADDRESS=0.0.0.0:2775`
+2. **Firewall**: Ensure port 2775 (or 2776 for TLS) is open and accessible
+3. **Docker port mapping**: If using Docker, verify `-p 2775:2775` is set correctly
+
+### Authentication fails on BIND
+
+- Verify your SMSGate **username** and **password** are correct
+- Ensure your SMSGate account is active
+- Check that the `GATEWAY__API_BASE_URL` points to the correct SMSGate instance
+- For Docker deployments, verify network connectivity between the SMPP Server and the Gateway API
+
+### Delivery receipts are not working
+
+- The `GATEWAY__WEBHOOK_BASE_URL` **must** be publicly accessible
+- Check that your SMPP Server is reachable from the SMSGate app on the device
+- Note: DELIVER_SM forwarding to the ESME client is currently **work in progress**
+
+### TLS/SMPPs connection fails
+
+- Verify both `SMPP__TLS_CERT` and `SMPP__TLS_KEY` are set to valid file paths
+- Ensure the certificate and key files are accessible to the SMPP Server process
+- The SMPPs listener runs on port **2776**, not 2775
+- For Docker, mount the certificate files as volumes: `-v /path/to/certs:/certs:ro`
+
+## ⚙️ Technical
+
+### What TON/NPI values should I use?
+
+The default configuration uses:
+
+| Parameter    | Default Value | Meaning                     |
+| ------------ | ------------- | --------------------------- |
+| `source_ton` | `0x01`        | International               |
+| `source_npi` | `0x01`        | E.164 (ISDN numbering plan) |
+| `dest_ton`   | `0x01`        | International               |
+| `dest_npi`   | `0x01`        | E.164 (ISDN numbering plan) |
+
+### What SMPP protocol version is supported?
+
+The SMPP Server implements **SMPP v3.4** using the [go-smpp](https://github.com/fiorix/go-smpp) library.
+
+### Can I run multiple SMPP Server instances?
+
+Yes. Each SMPP Server instance is stateless and connects to the same SMSGate API. You can run multiple instances behind a load balancer for high availability.
+
+### Does the SMPP Server support rate limiting?
+
+Rate limiting is **not currently implemented**. If you need rate limiting, configure it at the network level (e.g., reverse proxy, firewall rules) or in your SMPP client.
+
+### What happens on UNBIND?
+
+When a client sends an UNBIND PDU (or disconnects):
+
+1. The session state is transitioned back to Open
+2. Any registered webhook for that session is deregistered from the SMS Gateway
+3. The connection is closed gracefully
+
+## 📚 See Also
+
+- [SMPP Server Documentation](../services/smpp-server.md)
+- [SMPP Protocol Integration](../integration/smpp.md)
+- [SMSGate API Reference](../integration/api.md)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,6 +10,10 @@ To begin with any of these modes, you must first install the SMS Gateway for And
 
 For more details on how to use the API, please consult the [API](../integration/api.md) section.
 
+## SMPP Server Integration
+
+For organizations with existing SMPP-based infrastructure, the [SMPP Server](../services/smpp-server.md) provides a bridge between SMPP v3.4 clients and the SMSGate ecosystem. It operates as a separate service that translates SMPP protocol operations into REST API calls, enabling seamless integration with SMS aggregators and telecom-grade messaging platforms.
+
 ## Building Your Own Gateway
 
 Building your own gateway is an option that allows you to create an independent infrastructure without any connection to the public server at `api.sms-gate.app`. In most cases, this is not necessary, and you can use the [Private Server](./private-server.md) mode with all of its privacy features. However, if you require full control, please see [Custom Gateway Setup](./custom-gateway.md) section.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ SMS Gateway for Android turns your Android smartphone into an SMS and MMS gatewa
 🔌 Integration:
 
 - 🪝 **Webhooks:** Set up [webhooks](./features/webhooks.md) to be triggered on specified events.
+- 📡 **SMPP Server:** Bridge SMPP-compatible clients and SMS aggregators with the SMSGate via the industry-standard SMPP v3.4 protocol. See [SMPP Server](./services/smpp-server.md).
 - 🚀 **Twilio Fallback Service:** Provides a fallback mechanism for Twilio SMS messages using SMSGate. See [Twilio Fallback Service](./services/twilio-fallback.md) for more information.
 
 ## Ideal For

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -7,6 +7,9 @@ There are several ways to integrate the SMS Gateway for Android™ into your own
 - **📡 [API](./api.md)**  
     Use the API directly to send and receive SMS messages with maximum control and flexibility.
 
+- **📡 [SMPP](./smpp.md)**  
+    Connect SMPP-compatible clients and SMS aggregators using the industry-standard SMPP v3.4 protocol.
+
 - **📚 [Clients](./client-libraries.md)**  
     Install client libraries in various programming languages to simplify integration and accelerate development.
 

--- a/docs/integration/smpp.md
+++ b/docs/integration/smpp.md
@@ -1,0 +1,153 @@
+# 📡 SMPP Protocol
+
+The SMSGate supports the SMPP v3.4 protocol through a dedicated SMPP Server component. This guide covers how to integrate with the SMPP Server for sending SMS messages and receiving delivery receipts.
+
+## 📋 Overview
+
+SMPP (Short Message Peer-to-Peer) is a telecommunications industry protocol for exchanging SMS messages between external messaging entities and SMS centers. The SMPP Server bridges SMPP clients with the SMSGate ecosystem, allowing you to use existing SMPP-based infrastructure with Android devices.
+
+<div class="grid cards" markdown>
+
+- **🔌 When to Use SMPP**  
+    Use SMPP when you have existing SMPP-based infrastructure, work with SMS aggregators, or need standardized telecom protocol integration.
+
+- **🌐 When to Use REST API**  
+    Use the [REST API](./api.md) for simpler integrations, web applications, or when you need direct access to all SMSGate features.
+
+</div>
+
+## 🔌 Connection Details
+
+| Parameter  | Value               |
+| ---------- | ------------------- |
+| Protocol   | SMPP v3.4           |
+| Plain port | 2775                |
+| TLS port   | 2776 (SMPPs)        |
+| Encoding   | GSM 7-bit (default) |
+
+## 🔑 Authentication
+
+Authentication happens during the SMPP BIND sequence using your SMSGate credentials:
+
+| Field       | Value                            |
+| ----------- | -------------------------------- |
+| `system_id` | Your SMS Gateway username        |
+| `password`  | Your SMS Gateway password        |
+| Bind types  | `BIND_TX`, `BIND_RX`, `BIND_TRX` |
+
+### Authentication Flow
+
+```mermaid
+sequenceDiagram
+    participant ESME as SMPP Client
+    participant Server as SMPP Server
+    participant Gateway as SMSGate API
+
+    ESME->>Server: BIND_TRX (system_id, password)
+    Server->>Gateway: GET /devices (Basic Auth)
+    Server->>Gateway: Register webhook (for RX/TRX)
+    Server-->>ESME: BIND_RESP (system_id)
+```
+
+## 📤 Sending SMS
+
+Use the `SUBMIT_SM` PDU to send SMS messages. The SMPP Server translates this into an HTTP API call to the SMSGate.
+
+### Parameter Mapping
+
+| SMPP Field            | Gateway Mapping        | Notes                           |
+| --------------------- | ---------------------- | ------------------------------- |
+| `source_addr`         | Sender (optional)      | Overridden by TON/NPI settings  |
+| `destination_addr`    | Recipient phone number | E.164 format recommended        |
+| `short_message`       | SMS text content       | GSM 7-bit encoding              |
+| `registered_delivery` | Delivery receipt flag  | `0x01` to request receipt       |
+| `data_coding`         | Message encoding       | `0x00` = default, `0x08` = UCS2 |
+
+### Example: Submit SMS
+
+```bash title="SUBMIT_SM Example"
+# Using an SMPP client library (e.g., go-smpp, pysmpp, jSMPP)
+# Connect to SMPP Server and send SUBMIT_SM
+
+source_addr_ton: 0x01        # International
+source_addr_npi: 0x01        # E.164
+source_addr: ""              # Empty (uses device default)
+dest_addr_ton: 0x01          # International
+dest_addr_npi: 0x01          # E.164
+destination_addr: "+1234567890"
+short_message: "Hello from SMPP!"
+registered_delivery: 0x01    # Request delivery receipt
+```
+
+## 📊 Querying Status
+
+Use the `QUERY_SM` PDU to check the delivery status of a previously submitted message.
+
+### Message State Mapping
+
+| Gateway State        | SMPP `message_state` | Description                 |
+| -------------------- | -------------------- | --------------------------- |
+| `pending`            | Scheduled (0)        | Message queued for delivery |
+| `processed` / `sent` | Enroute (1)          | Message sent to device      |
+| `delivered`          | Delivered (2)        | Successfully delivered      |
+| `failed`             | Undeliverable (5)    | Delivery failed             |
+
+### Example: Query Status
+
+```bash title="QUERY_SM Example"
+message_id: "msg_abc123"    # From SUBMIT_SM_RESP
+source_addr_ton: 0x01
+source_addr_npi: 0x01
+source_addr: ""
+```
+
+## 🔄 Webhook Lifecycle
+
+For `BIND_RECEIVER` and `BIND_TRANSCEIVER` sessions, the SMPP Server manages webhook registration automatically:
+
+```mermaid
+sequenceDiagram
+    participant ESME as SMPP Client
+    participant Server as SMPP Server
+    participant Gateway as SMS Gateway API
+
+    ESME->>Server: BIND_TRX
+    Server->>Gateway: Register webhook
+    Note over Gateway: Webhook URL: {base}/api/smpp/v1/webhook?session={id}
+    Gateway-->>Server: Webhook registered
+
+    Gateway->>Server: Delivery status webhook
+    Note over Server: DELIVER_SM forwarding (WIP)
+    Server-->>ESME: DELIVER_SM PDU
+
+    ESME->>Server: UNBIND
+    Server->>Gateway: Deregister webhook
+    Gateway-->>Server: Webhook removed
+```
+
+## ⚠️ Error Mapping
+
+The SMPP Server maps HTTP API errors to SMPP error codes:
+
+| HTTP Error | SMPP Error Code                | Description                 |
+| ---------- | ------------------------------ | --------------------------- |
+| 400        | `ESME_RINVBNDSTS` (0x00000004) | Invalid bind state          |
+| 401        | `ESME_RBINDFAIL` (0x0000000D)  | Authentication failed       |
+| 403        | `ESME_RBINDFAIL` (0x0000000D)  | Forbidden                   |
+| 404        | `ESME_RINVDSTADR` (0x00000006) | Invalid destination address |
+| 409        | `ESME_RSYSERR` (0x00000008)    | System error                |
+| 422        | `ESME_RINVMSG` (0x00000006)    | Invalid message             |
+| 429        | `ESME_RTHROTTLED` (0x00000058) | Too many requests           |
+| 500        | `ESME_RSYSERR` (0x00000008)    | Internal server error       |
+| 502        | `ESME_RSYSERR` (0x00000008)    | Bad gateway                 |
+| 503        | `ESME_RSYSERR` (0x00000008)    | Service unavailable         |
+
+!!! note "Error Code Reference"
+    The full error mapping covers 36+ SMPP v3.4 error codes. See the [SMPP Server source code](https://github.com/android-sms-gateway/smpp-server) for the complete mapping.
+
+## 📚 See Also
+
+- [SMPP Server Documentation](../services/smpp-server.md)
+- [REST API Reference](./api.md)
+- [Authentication Guide](./authentication.md)
+- [SMPP Server GitHub Repository](https://github.com/android-sms-gateway/smpp-server)

--- a/docs/services/smpp-server.md
+++ b/docs/services/smpp-server.md
@@ -1,0 +1,236 @@
+# 📡 SMPP Server
+
+The SMPP Server is a standalone SMPP v3.4 protocol service that bridges SMPP-compatible clients (SMS aggregators, messaging platforms) with the SMSGate ecosystem. It enables external systems to submit SMS messages and receive delivery receipts using the industry-standard SMPP protocol.
+
+!!! warning "Non-Affiliated Project"
+    The SMPP Server is a separate project and is **not affiliated with, endorsed by, or sponsored by** any SMPP protocol standards body. It is an independent open-source project.
+
+## 📖 Overview
+
+The SMPP Server acts as a bridge between SMPP clients and the SMSGate REST API. It translates SMPP protocol operations into HTTP API calls, allowing existing SMPP-based infrastructure to work seamlessly with Android devices running the SMS Gateway app.
+
+```mermaid
+sequenceDiagram
+    participant Client as SMPP Client<br/>(ESME)
+    participant SMPP as SMPP Server
+    participant Gateway as SMSGate REST API
+    participant Device as Android Device
+
+    Client->>SMPP: BIND_TRX (system_id/password)
+    SMPP->>Gateway: Validate credentials (GET /devices)
+    SMPP->>Gateway: Register webhook for receipts
+    SMPP-->>Client: BIND_RESP (success)
+
+    Client->>SMPP: SUBMIT_SM
+    SMPP->>Gateway: POST /api/3rdparty/v1/messages
+    Gateway->>Device: Send SMS
+    Gateway-->>SMPP: Message ID
+    SMPP-->>Client: SUBMIT_SM_RESP (message_id)
+
+    Device-->>Gateway: Delivery status
+    Gateway-->>SMPP: Webhook callback
+    Note over SMPP: DELIVER_SM forwarding (WIP)
+    SMPP-->>Client: DELIVER_SM
+```
+
+## 🏗️ Architecture
+
+The SMPP Server is a standalone Go service with no shared database. All communication with the SMS Gateway happens via the REST API using the [client-go SDK](https://github.com/android-sms-gateway/client-go).
+
+<div class="grid cards" markdown>
+
+- **🔌 SMPP Listener**  
+    Listens on port 2775 (plain SMPP) and optionally port 2776 (SMPPs/TLS) for incoming connections.
+
+- **👤 Sessions Manager**  
+    Manages SMPP session state machines with thread-safe PDU routing and state transitions.
+
+- **🌐 HTTP Gateway Client**  
+    Per-session authenticated HTTP client with automatic webhook registration for delivery receipts.
+
+- **📊 Health & Metrics Server**  
+    Built-in HTTP server on port 3000 providing health checks, Prometheus metrics, and OpenAPI documentation.
+
+</div>
+
+## 📦 Installation
+
+### Option A: Pre-built Binary
+
+Download the latest release binary from [GitHub Releases](https://github.com/android-sms-gateway/smpp-server/releases/latest):
+
+```bash title="Download Release Binary"
+curl -LO https://github.com/android-sms-gateway/smpp-server/releases/latest/download/smpp-server_Linux_x86_64.tar.gz
+tar -xzf smpp-server_Linux_x86_64.tar.gz
+./smpp-server
+```
+
+### Option B: Docker
+
+Pull and run the Docker image from GitHub Container Registry:
+
+```bash title="Run Docker Container"
+docker run \
+  -p 2775:2775 \
+  -e SMPP__BIND_ADDRESS=0.0.0.0:2775 \
+  -e GATEWAY__API_BASE_URL=https://api.sms-gate.app/3rdparty/v1 \
+  -e GATEWAY__WEBHOOK_BASE_URL=https://your-public-url \
+  ghcr.io/android-sms-gateway/smpp-server:latest
+```
+
+### Option C: Build from Source
+
+```bash title="Build from Source"
+git clone https://github.com/android-sms-gateway/smpp-server.git
+cd smpp-server
+go build -o smpp-server .
+./smpp-server
+```
+
+!!! note "Build Requirement"
+    Requires **Go 1.25+** to build from source.
+
+## ⚙️ Configuration
+
+Configuration is loaded via environment variables or a `.env` file. An optional YAML config file can be specified via the `CONFIG_PATH` environment variable.
+
+| Config Key                 | Env Var                     | Default                                | Description                                                          |
+| -------------------------- | --------------------------- | -------------------------------------- | -------------------------------------------------------------------- |
+| `http.address`             | `HTTP__ADDRESS`             | `127.0.0.1:3000`                       | HTTP API bind address (health, metrics, OpenAPI)                     |
+| `smpp.bind_address`        | `SMPP__BIND_ADDRESS`        | `127.0.0.1:2775`                       | SMPP server bind address                                             |
+| `smpp.tls_cert`            | `SMPP__TLS_CERT`            | *(empty)*                              | TLS certificate file path (enables SMPPs on port 2776)               |
+| `smpp.tls_key`             | `SMPP__TLS_KEY`             | *(empty)*                              | TLS private key file path                                            |
+| `gateway.api_base_url`     | `GATEWAY__API_BASE_URL`     | `https://api.sms-gate.app/3rdparty/v1` | SMSGate REST API base URL                                            |
+| `gateway.webhook_base_url` | `GATEWAY__WEBHOOK_BASE_URL` | *(empty)*                              | **Required** for delivery receipts: public URL for webhook callbacks |
+| `gateway.timeout`          | `GATEWAY__TIMEOUT`          | `60s`                                  | HTTP client timeout for gateway requests                             |
+
+!!! important "Webhook URL Requirement"
+    The `GATEWAY__WEBHOOK_BASE_URL` must be publicly reachable by the SMSGate for delivery receipt webhooks to work. The webhook URL follows the pattern: `{GATEWAY_WEBHOOK_BASE_URL}/api/smpp/v1/webhook?session={session_id}`
+
+## 🔐 Authentication
+
+SMPP clients authenticate using their SMSGate credentials via the BIND sequence:
+
+| Bind Type          | PDU        | Description                              |
+| ------------------ | ---------- | ---------------------------------------- |
+| `BIND_TRANSMITTER` | `BIND_TX`  | Send-only session (submit SMS)           |
+| `BIND_RECEIVER`    | `BIND_RX`  | Receive-only session (delivery receipts) |
+| `BIND_TRANSCEIVER` | `BIND_TRX` | Bidirectional session (send + receive)   |
+
+The authentication flow:
+
+1. Client sends a BIND PDU with `system_id` (SMSGate username) and `password`
+2. SMPP Server validates credentials against the SMSGate REST API
+3. On success, the session is established and the client can send/receive PDUs
+4. For **RECEIVER** and **TRANSCEIVER** binds, a dynamic webhook is registered for delivery receipts
+5. On **UNBIND**, the webhook is deregistered and the session is cleaned up
+
+!!! tip "Recommended Bind Type"
+    Use `BIND_TRANSCEIVER` for most use cases to support both sending and receiving in a single connection.
+
+## 📡 SMPP Operations
+
+### Supported PDUs
+
+| Operation    | PDU              | Description                        |
+| ------------ | ---------------- | ---------------------------------- |
+| Bind         | `BIND_TX/RX/TRX` | Authenticate and establish session |
+| Submit SMS   | `SUBMIT_SM`      | Send SMS via the gateway           |
+| Query Status | `QUERY_SM`       | Check message delivery state       |
+| Unbind       | `UNBIND`         | Gracefully close session           |
+| Keep-Alive   | `ENQUIRE_LINK`   | Maintain connection health         |
+
+### Unsupported PDUs
+
+The following PDUs are recognized but return error responses:
+
+- `DATA_SM` — Not supported
+- `CANCEL_SM` — Not supported
+- `REPLACE_SM` — Not supported
+- `SUBMIT_MULTI` — Not supported
+
+## 🔒 TLS/SMPPs Configuration
+
+To enable encrypted SMPP connections (SMPPs), provide TLS certificate and key paths:
+
+```bash title="Enable TLS/SMPPs"
+docker run \
+  -p 2776:2776 \
+  -v /path/to/certs:/certs:ro \
+  -e SMPP__TLS_CERT=/certs/server.crt \
+  -e SMPP__TLS_KEY=/certs/server.key \
+  -e SMPP__BIND_ADDRESS=0.0.0.0:2776 \
+  ghcr.io/android-sms-gateway/smpp-server:latest
+```
+
+!!! tip "TLS Certificates"
+    You can use the [Certificate Authority service](./ca.md) to generate SSL certificates for private IP addresses.
+
+## 📬 Delivery Receipts
+
+When using `BIND_RECEIVER` or `BIND_TRANSCEIVER`, the SMPP Server automatically:
+
+1. Registers a webhook with the SMSGate upon successful bind
+2. Receives delivery status updates via webhook callbacks
+3. Maps gateway message states to SMPP `message_state` values
+
+### Message State Mapping
+
+| Gateway State        | SMPP `message_state` | Description                 |
+| -------------------- | -------------------- | --------------------------- |
+| `pending`            | Scheduled (0)        | Message queued for delivery |
+| `processed` / `sent` | Enroute (1)          | Message sent to device      |
+| `delivered`          | Delivered (2)        | Successfully delivered      |
+| `failed`             | Undeliverable (5)    | Delivery failed             |
+
+!!! warning "Work in Progress"
+    Delivery receipt forwarding to the ESME client via `DELIVER_SM` PDUs is currently **work in progress**. The webhook is registered, but the forwarding logic is not yet fully implemented.
+
+## 🚀 Deployment
+
+### Docker Compose Example
+
+```yaml title="docker-compose.yml"
+services:
+  smpp-server:
+    image: ghcr.io/android-sms-gateway/smpp-server:latest
+    ports:
+      - "2776:2776"
+      - "3000:3000"
+    environment:
+      - SMPP__BIND_ADDRESS=0.0.0.0:2776
+      - SMPP__TLS_CERT=/certs/server.crt
+      - SMPP__TLS_KEY=/certs/server.key
+      - GATEWAY__API_BASE_URL=https://api.sms-gate.app/3rdparty/v1
+      - GATEWAY__WEBHOOK_BASE_URL=https://smpp.example.com
+      - GATEWAY__TIMEOUT=60s
+    volumes:
+      - ./certs:/certs:ro
+    restart: unless-stopped
+```
+
+### Health Check
+
+The built-in health endpoint is available at `GET /health` on the HTTP server (default port 3000):
+
+```bash title="Health Check"
+curl http://localhost:3000/health
+```
+
+## ⚠️ Known Limitations
+
+| Limitation            | Status          | Description                                     |
+| --------------------- | --------------- | ----------------------------------------------- |
+| Rate limiting         | Not implemented | No per-client rate limiting                     |
+| Multi-part SMS        | Not supported   | No message concatenation                        |
+| UCS2 encoding         | Not supported   | No binary/Unicode message support               |
+| SubmitMulti           | Not supported   | Single recipient only                           |
+| DELIVER_SM forwarding | WIP             | Webhook registered, forwarding not complete     |
+| Prometheus metrics    | Planned         | Metrics middleware configured but not finalized |
+
+## 📚 See Also
+
+- [SMPP Protocol Integration](../integration/smpp.md)
+- [SMSGate API Reference](../integration/api.md)
+- [Certificate Authority](./ca.md)
+- [SMPP Server GitHub Repository](https://github.com/android-sms-gateway/smpp-server)

--- a/docs/services/twilio-fallback.md
+++ b/docs/services/twilio-fallback.md
@@ -1,6 +1,6 @@
 # 🚀 Twilio™ Fallback Service
 
-!!! warning
+!!! warning "Not Affiliated with Twilio"
     This service is not affiliated with, endorsed by, or sponsored by Twilio. It is an independent project that utilizes the Twilio API.
 
 ## 📖 Overview
@@ -82,4 +82,5 @@ docker run -p 3000:3000 --env-file .env ghcr.io/android-sms-gateway/twilio-fallb
 ## 📚 See Also
 
 * [SMSGate API](../integration/api.md)
+* [SMPP Server](./smpp-server.md)
 * [Twilio Webhooks](https://www.twilio.com/docs/usage/webhooks/messaging-webhooks#outbound-message-status-callback)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Integration:
       - Overview: integration/index.md
       - API: integration/api.md
+      - SMPP Protocol: integration/smpp.md
       - Authentication: integration/authentication.md
       - Libraries: integration/client-libraries.md
       - CLI: integration/cli.md
@@ -71,12 +72,14 @@ nav:
       - Errors: faq/errors.md
       - Authentication: faq/authentication.md
       - Private Server: faq/private-server.md
+      - SMPP Server: faq/smpp-server.md
   - Resources:
       - Examples: resources/examples.md
       - Use Cases: resources/use-cases.md
       - Third-Party: resources/3rdparty.md
   - Services:
       - Twilio Fallback: services/twilio-fallback.md
+      - SMPP Server: services/smpp-server.md
       - Certificate Authority: services/ca.md
   - Blog: blog/index.md
   - Pricing: pricing.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive SMPP Server docs: overview, integration guide, service reference, FAQ, troubleshooting, and quick-start (including Docker and config).
  * Documented SMPP↔HTTP behavior: bindings, message mapping, delivery receipts, TLS notes, and known limitations/roadmap items.
  * Updated getting-started and site navigation to include SMPP resources; added link from Twilio fallback docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/android-sms-gateway/docs-web/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->