### PR TITLE
[cli] add table output format

### DIFF
--- a/docs/integration/cli.md
+++ b/docs/integration/cli.md
@@ -80,11 +80,12 @@ The following table summarizes the available command-line options:
 
 ### Output Formats
 
-The CLI supports three output formats:
+The CLI supports four output formats:
 
 1. `text`: Human-readable text output (default)
 2. `json`: Pretty printed JSON-formatted output
 3. `raw`: One-line JSON-formatted output
+4. `table`: Tab-aligned columnar output for lists and sub-tables
 
 !!! note
     When the exit code is not `0`, the error description is printed to stderr without any formatting.
@@ -567,6 +568,14 @@ Recipients:
 
 ```json
 {"id":"zXDYfTmTVf3iMd16zzdBj","state":"Pending","isHashed":false,"isEncrypted":false,"recipients":[{"phoneNumber":"+12025550123","state":"Pending"},{"phoneNumber":"+12025550124","state":"Pending"}],"states":{}}
+```
+
+### Table
+
+```text
+ID                                    EVENT          URL                              DEVICE ID
+123e4567-e89b-12d3-a456-426614174000  sms:received   https://example.com/webhook      dev-abc
+def45678-e89b-12d3-a456-426614174000  sms:sent       https://example.com/other        -
 ```
 
 ## 📚 See Also


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI output format documentation to include a new `table` format alongside `text`, `json`, and `raw`.
  * Clarified that the CLI now supports four output formats and described `table` as tab-aligned column output.
  * Added an example showing webhook results in a table with columns for ID, event, URL, and device ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->