### PR TITLE
[features] message cancellation

### DIFF
--- a/docs/features/sending-messages.md
+++ b/docs/features/sending-messages.md
@@ -20,6 +20,40 @@ The **Sending Messages** feature provides a comprehensive API for delivering bot
 
 </div>
 
+## ❌ Cancelling Messages
+
+Cancelling allows you to abort a pending message before the device processes it. This is useful for scheduled messages or when you need to retract a message that hasn't been sent yet.
+
+### Cancellation Flow
+
+1. **Request cancellation**: `DELETE /3rdparty/v1/messages/{id}` with `messages:cancel` scope
+2. **Server transition**: Message state changes from `Pending` → `Cancelling`
+3. **Device notification**: Server sends a push/SSE event to the device
+4. **Device confirmation**: Device marks the message as `Cancelled` (or sends it if already processed)
+
+!!! note "Two-Phase Cancellation"
+    If the device has already started sending the message, it will transition to `Sent`/`Delivered`/`Failed` instead of `Cancelled`. The cancellation only takes effect while the message is still `Pending`.
+
+### Example
+
+```bash
+curl -X DELETE "https://api.sms-gate.app/3rdparty/v1/messages/zXDYfTmTVf3iMd16zzdBj" \
+  -u "username:password"
+```
+
+### Response
+
+If the message was successfully marked for cancellation:
+
+```json
+{
+  "id": "zXDYfTmTVf3iMd16zzdBj",
+  "state": "Cancelling"
+}
+```
+
+If the message was not in `Pending` state, the API returns `400 Bad Request` with an error message.
+
 ## 📤 API Request Structure
 
 === "Text Message"

--- a/docs/features/status-tracking.md
+++ b/docs/features/status-tracking.md
@@ -54,6 +54,11 @@ The app allows you to track the status of messages using multiple methods.
 stateDiagram-v2
     direction LR
     [*] --> Pending
+    Pending --> Cancelling
+    Cancelling --> Cancelled
+    Cancelling --> Sent
+    Cancelling --> Failed
+    Cancelled --> [*]
     Pending --> Processed
     Processed --> Sent
     Sent --> Delivered
@@ -69,6 +74,10 @@ stateDiagram-v2
 
 - :hourglass: **Pending**  
   Message queued, awaiting device processing
+- :no_entry: **Cancelling**  
+  Server requested cancellation, awaiting device confirmation
+- :no_entry: **Cancelled**  
+  Message successfully cancelled before processing
 - :gear: **Processed**  
   Device prepared message, handed to Android SMS API
 - :outbox_tray: **Sent**  
@@ -94,6 +103,7 @@ stateDiagram-v2
     | ------------- | ---------------------- |
     | Any pending   | :hourglass: Pending    |
     | Any processed | :gear: Processed       |
+    | All cancelled | :no_entry: Cancelled   |
     | All delivered | :inbox_tray: Delivered |
     | All failed    | :x: Failed             |
     | Otherwise     | :outbox_tray: Sent     |

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -9,18 +9,16 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
 - :incoming_envelope: **sms:received**
     - `messageId`: Content-based ID
     - `message`: SMS content
-    - `sender` ⭐: Sender's phone number (use instead of deprecated `phoneNumber`)
+    - `sender` ⭐: Sender's phone number
     - `recipient` 📍: Device's phone number that received the message (may be `null` if unavailable)
-    - `phoneNumber` ⚠️: Sender's number (deprecated, use `sender`)
     - `simNumber`: SIM index (nullable)
     - `receivedAt`: Local timestamp
 
 - :material-database: **sms:data-received**
     - `messageId`: Content-based ID
     - `data`: Base64-encoded data message
-    - `sender` ⭐: Sender's phone number (use instead of deprecated `phoneNumber`)
+    - `sender` ⭐: Sender's phone number
     - `recipient` 📍: Device's phone number that received the message (may be `null` if unavailable)
-    - `phoneNumber` ⚠️: Sender's number (deprecated, use `sender`)
     - `simNumber`: SIM index (nullable)
     - `receivedAt`: Local timestamp
 
@@ -30,17 +28,15 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
     - `subject`: Message subject line (nullable)
     - `size`: Attachment size in bytes
     - `contentClass`: MMS content classification (nullable)
-    - `sender` ⭐: Sender's phone number (use instead of deprecated `phoneNumber`)
+    - `sender` ⭐: Sender's phone number
     - `recipient` 📍: Device's phone number that received the message (may be `null` if unavailable)
-    - `phoneNumber` ⚠️: Sender's number (deprecated, use `sender`)
     - `simNumber`: SIM index (nullable)
     - `receivedAt`: Local timestamp
 
 - :outbox_tray: **sms:sent**
     - `messageId`: Unique ID
     - `sender` ⭐: Device's phone number
-    - `recipient` 📍: Recipient's phone number (use instead of deprecated `phoneNumber`)
-    - `phoneNumber` ⚠️: Recipient (deprecated, use `recipient`)
+    - `recipient` 📍: Recipient's phone number
     - `simNumber`: SIM index (nullable)
     - `partsCount`: Number of message parts
     - `sentAt`: Local timestamp
@@ -48,19 +44,24 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
 - :white_check_mark: **sms:delivered**
     - `messageId`: Unique ID
     - `sender` ⭐: Device's phone number
-    - `recipient` 📍: Recipient's phone number (use instead of deprecated `phoneNumber`)
-    - `phoneNumber` ⚠️: Recipient (deprecated, use `recipient`)
+    - `recipient` 📍: Recipient's phone number
     - `simNumber`: SIM index (nullable)
     - `deliveredAt`: Local timestamp
 
 - :x: **sms:failed**
     - `messageId`: Unique ID
     - `sender` ⭐: Device's phone number
-    - `recipient` 📍: Recipient's phone number (use instead of deprecated `phoneNumber`)
-    - `phoneNumber` ⚠️: Recipient (deprecated, use `recipient`)
+    - `recipient` 📍: Recipient's phone number
     - `simNumber`: SIM index (nullable)
     - `reason`: Error details
     - `failedAt`: Local timestamp
+
+- :no_entry: **sms:cancelled**
+    - `messageId`: Unique ID
+    - `sender` ⭐: Device's phone number
+    - `recipient` 📍: Recipient's phone number
+    - `simNumber`: SIM index (nullable)
+    - `cancelledAt`: Local timestamp
 
 - :ping_pong: **system:ping**
     - `health`: [Healthcheck status](./health.md)
@@ -172,6 +173,7 @@ In Cloud and Private modes, please allow some time for the webhooks list to sync
 - `sms:data-received`: Send a data SMS to port 53739.
 - `mms:received`: Send an MMS message to the device.
 - `sms:sent`/`delivered`/`failed`: Send an SMS *from* the app to trigger these events.
+- `sms:cancelled`: Send an SMS via the cloud/private API, then cancel it via `DELETE /3rdparty/v1/messages/{id}` while the message is still pending.
 - `system:ping`: Enable the ping feature in the app’s **Settings > Ping**.
 - `app:started`: Restart the app.
 
@@ -289,6 +291,23 @@ Your server will receive a POST request with a payload like:
     }
     ```
 
+=== "sms:cancelled"
+    ```json
+    {
+      "deviceId": "ffffffffceb0b1db0000018e937c815b",
+      "event": "sms:cancelled",
+      "id": "Ey6ECgOkVVFjz3CL48B8C",
+      "payload": {
+        "messageId": "msg-456",
+        "sender": "+1234567890",
+        "recipient": "+9998887777",
+        "simNumber": 1,
+        "cancelledAt": "2026-06-22T10:00:00.000+07:00"
+      },
+      "webhookId": "LreFUt-Z3sSq0JufY9uWB"
+    }
+    ```
+
 === "app:started"
     ```json
     {
@@ -356,6 +375,7 @@ When sending SMS messages longer than the standard limits (160 characters for GS
 | `sms:sent`      | Triggered once when all parts of the outgoing message are successfully sent, the `partsCount` field is set to the number of parts |
 | `sms:delivered` | Triggered once **for each individual part** of the message                                                                        |
 | `sms:failed`    | Triggered once if any part of the message fails to send or deliver; other parts may still succeed                                 |
+| `sms:cancelled` | Triggered once when the pending message is cancelled before any part is sent                                                      |
 
 !!! tip "Handling Multipart Delivery Reports"
     To avoid processing duplicate deliveries in your webhook handler:

--- a/docs/integration/authentication.md
+++ b/docs/integration/authentication.md
@@ -164,11 +164,12 @@ All scopes follow the pattern: `resource:action`
 
 #### Messages Scopes
 
-| Scope           | Description                                   | Access Level |
-| --------------- | --------------------------------------------- | ------------ |
-| `messages:send` | Permission to send SMS messages               | Write        |
-| `messages:read` | Permission to read individual message details | Read         |
-| `messages:list` | Permission to list and view messages          | Read         |
+| Scope              | Description                                   | Access Level |
+| ------------------ | --------------------------------------------- | ------------ |
+| `messages:send`    | Permission to send SMS messages               | Write        |
+| `messages:read`    | Permission to read individual message details | Read         |
+| `messages:list`    | Permission to list and view messages          | Read         |
+| `messages:cancel`  | Permission to cancel pending messages         | Delete       |
 
 #### Devices Scopes
 
@@ -217,6 +218,7 @@ All scopes follow the pattern: `resource:action`
 | `/3rdparty/v1/messages`              | GET    | `messages:list`   | List messages       |
 | `/3rdparty/v1/messages`              | POST   | `messages:send`   | Send a new message  |
 | `/3rdparty/v1/messages/:id`          | GET    | `messages:read`   | Get message details |
+| `/3rdparty/v1/messages/:id`          | DELETE | `messages:cancel` | Cancel pending message |
 | `/3rdparty/v1/messages/inbox/export` | POST   | `messages:export` | Export messages     |
 
 #### Devices API


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cancelling pending messages, including the two-phase flow, example API call, and response/error cases.
  * Updated message status tracking to include cancellation states and lifecycle transitions/terminal outcomes (including multi-recipient “all cancelled”).
  * Documented the `sms:cancelled` webhook event, including payload example and multipart behavior.
  * Expanded JWT scope documentation to include `messages:cancel` and mapped it to the message cancellation endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->