### PR TITLE
[settings] add receiver section

### DIFF
--- a/docs/features/settings-management.md
+++ b/docs/features/settings-management.md
@@ -53,6 +53,9 @@ The settings parameters are represented as a JSON object. The structure includes
         "send_interval_min": null,
         "sim_selection_mode": "OSDefault"
     },
+    "receiver": {
+        "content_provider_enabled": true
+    },
     "ping": {
         "interval_seconds": null
     },
@@ -89,6 +92,17 @@ When operating in Local mode, you can also configure the following Cloud/Private
     - `encryption.passphrase`
     - `webhooks.signing_key`
     - `gateway.private_token`
+
+### Receiver Settings 📡
+
+Controls how the app monitors for incoming SMS messages.
+
+| Setting                             | Type    | Default | Description                                                                                                                                                                                                                                                      |
+| ----------------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `receiver.content_provider_enabled` | boolean | `true`  | When enabled, the app also monitors the SMS content provider for incoming messages as a fallback for carriers that intercept the `SMS_RECEIVED` broadcast. Disable if you experience duplicate webhook events and your carrier delivers the broadcast correctly. |
+
+!!! note "Restart Required"
+    Changes to receiver settings require an app restart to take effect.
 
 ### Push Notifications for Syncing Settings 📱
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the settings-management guide with a new receiver configuration example.
  * Added a “Receiver Settings” section describing the new content provider option and its default behavior.
  * Clarified that changes to receiver-related settings require restarting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->