### PR TITLE
[webhooks] provide cloud tester

### DIFF
--- a/docs/faq/webhooks.md
+++ b/docs/faq/webhooks.md
@@ -125,6 +125,12 @@ Use this build when:
     - Never expose insecure builds to public networks
     - This build bypasses Android's cleartext traffic restrictions
 
+## :material-webhook: How can I test webhooks without setting up my own server?
+
+We provide a public Webhook Tester at `https://webhook.sms-gate.app`. Create a session, use its unique URL as your webhook endpoint, and inspect incoming requests in real-time.
+
+See the [Webhook Tester guide](../features/webhooks.md#webhook-tester) for details.
+
 ## 📨 Why do I receive multiple delivery reports for a single message?
 
 When sending SMS messages longer than the standard character limits (160 characters for GSM/7-bit encoding or 70 characters for Unicode), the message is automatically split into multiple parts.

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -94,7 +94,7 @@ Before you begin, ensure the following:
 For your webhooks to work, you need an HTTP server capable of handling HTTPS POST requests. This server will be the endpoint for the incoming webhook data.
 
 - **Production**: Use a valid SSL certificate.
-- **Testing**: Tools like [webhook.site](https://webhook.site) provide temporary endpoints to capture payloads.
+- **Testing**: Tools like [webhook.site](https://webhook.site) or our [Webhook Tester](#webhook-tester) provide temporary endpoints to capture payloads.
 
 ### Step 2: Register Your Webhook Endpoint 📝
 
@@ -326,6 +326,40 @@ curl -X DELETE -u <username>:<password> \
   'https://api.sms-gate.app/3rdparty/v1/webhooks/LreFUt-Z3sSq0JufY9uWB'
 ```
 
+## Webhook Tester 🧪
+
+The Webhook Tester provides a convenient way to inspect webhook requests without setting up your own server. Powered by [webhook-tester](https://github.com/tarampampam/webhook-tester), it captures incoming HTTP requests and displays them in a web UI for real-time debugging. Available at `https://webhook.sms-gate.app` for all users.
+
+### Quick Start
+
+1. Visit the Webhook Tester URL in your browser
+2. A session is automatically created, generating a unique URL like `https://webhook.sms-gate.app/550e8400-e29b-41d4-a716-446655440000`
+3. Register this URL as your webhook endpoint:
+
+   ```sh
+   curl -X POST -u <username>:<password> \
+     -H "Content-Type: application/json" \
+     -d '{
+       "url": "https://webhook.sms-gate.app/550e8400-e29b-41d4-a716-446655440000",
+       "event": "sms:received"
+     }' \
+     https://api.sms-gate.app/3rdparty/v1/webhooks
+   ```
+4. Trigger the event (e.g., send an SMS to the device)
+5. The incoming webhook request — including headers, body, and timing — appears instantly in the browser
+
+### Constraints
+
+| Setting            | Value                         |
+| ------------------ | ----------------------------- |
+| Session TTL        | 24 hours                      |
+| Max request body   | 10 KB                         |
+| General rate limit | 10 requests/second (burst 20) |
+| Capture rate limit | 5 requests/second (burst 10)  |
+
+!!! tip
+    The Webhook Tester is ideal for development and debugging only. Do not send production or sensitive SMS traffic to it. For production, use your own HTTPS endpoint with [payload signature verification](`#payload-signing`).
+
 ## Local Network Solutions 🏠
 
 For webhooks within private networks:
@@ -473,7 +507,7 @@ The signing key is randomly generated at first request and can be changed in **S
     2. Ensure the device can reach your server
     3. Verify SSL certificate validity
     4. Check device and server logs
-    5. Test with [webhook.site](https://webhook.site) temporary endpoint
+    5. Test with [webhook.site](https://webhook.site) or our [Webhook Tester](#webhook-tester) temporary endpoint
 
 !!! bug "Signature Validation Issues"
     - Ensure timestamp is UTC Unix time in seconds

--- a/docs/getting-started/webhooks.md
+++ b/docs/getting-started/webhooks.md
@@ -9,7 +9,7 @@ Webhooks provide real-time notifications about SMS events. Follow these steps to
 1. **HTTPS Endpoint**:
     - Webhook URLs must use HTTPS except for `http://127.0.0.1` (localhost)
     - For private IP addresses (like `192.168.x.x`), use our [Certificate Authority](../services/ca.md) to generate trusted certificates
-    - Testing services like [webhook.site](https://webhook.site) provide HTTPS endpoints
+    - Testing services like [webhook.site](https://webhook.site) or our [Webhook Tester](../features/webhooks.md#webhook-tester) provide HTTPS endpoints
 
 2. **Network Access**:
     - Device must have internet access to reach external endpoints


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for testing webhooks without a personal server.
  * Introduced the hosted Webhook Tester as a temporary endpoint for capturing webhook payloads.
  * Updated setup and troubleshooting docs to include additional webhook testing options and quick-start steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->