### PR TITLE
[webhooks] batching support

### DIFF
--- a/docs/features/reading-messages.md
+++ b/docs/features/reading-messages.md
@@ -6,11 +6,10 @@ The app not only allows receiving incoming messages in real-time via webhooks bu
 
 The app provides three endpoints for reading messages:
 
-| Endpoint                                                   | Method | Description                                          |
-| ---------------------------------------------------------- | ------ | ---------------------------------------------------- |
-| [`GET /inbox`](#get-inbox)                                 | GET    | List incoming messages with filtering and pagination |
-| [`POST /inbox/refresh`](#post-inboxrefresh)                | POST   | Refresh inbox messages without triggering webhooks   |
-| [`POST /messages/inbox/export`](#post-messagesinboxexport) | POST   | Export messages via webhooks                         |
+| Endpoint                                    | Method | Description                                          |
+| ------------------------------------------- | ------ | ---------------------------------------------------- |
+| [`GET /inbox`](#get-inbox)                  | GET    | List incoming messages with filtering and pagination |
+| [`POST /inbox/refresh`](#post-inboxrefresh) | POST   | Refresh inbox messages without triggering webhooks   |
 
 
 !!! note
@@ -59,7 +58,7 @@ curl -u <username>:<password> \
 
 ### POST /inbox/refresh
 
-Refreshes inbox messages without triggering webhooks. This re-processes messages internally.
+Triggers inbox refresh with configurable webhook delivery mode.
 
 **Endpoint:** `POST /inbox/refresh`
 
@@ -68,39 +67,41 @@ Refreshes inbox messages without triggering webhooks. This re-processes messages
 {
   "deviceId": "<device-id>",
   "since": "2024-01-01T00:00:00Z",
-  "until": "2024-12-31T23:59:59Z"
+  "until": "2024-12-31T23:59:59Z",
+  "webhookDelivery": "Individual"
 }
 ```
 
-**Example Request:**
-```bash title="Refresh inbox messages"
+**Webhook Delivery Modes:**
+
+| Value        | Description                                                    |
+| ------------ | -------------------------------------------------------------- |
+| `Individual` | Each message triggers its own webhook (default behavior)       |
+| `Batch`      | Messages are grouped into batch webhooks (up to 100 per batch) |
+| `Disabled`   | Messages are saved but no webhooks are triggered               |
+
+**Example — Export with Batch Webhooks:**
+```bash title="Batch export"
 curl -X POST -u <username>:<password> \
   -H "Content-Type: application/json" \
-  -d '{ "deviceId": "<device-id>", "since": "2024-01-01T00:00:00Z", "until": "2024-12-31T23:59:59Z" }' \
-  http://<device_local_ip>:8080/inbox/refresh
+  -d '{
+    "since": "2024-06-01T00:00:00Z",
+    "until": "2024-06-30T23:59:59Z",
+    "webhookDelivery": "Batch"
+  }' \
+  https://api.sms-gate.app/3rdparty/v1/inbox/refresh
 ```
 
-### POST /messages/inbox/export
-
-Initiates export of inbox messages via webhooks. Triggers `sms:received` webhook for each message in the specified period.
-
-**Endpoint:** `POST /messages/inbox/export`
-
-**Request Body:**
-```json title="Request body"
-{
-  "deviceId": "<device-id>",
-  "since": "2024-01-01T00:00:00Z",
-  "until": "2024-12-31T23:59:59Z"
-}
-```
-
-**Example Request:**
-```bash title="Export messages via webhooks"
+**Example — Export without Webhooks:**
+```bash title="Silent export"
 curl -X POST -u <username>:<password> \
   -H "Content-Type: application/json" \
-  -d '{ "deviceId": "<device-id>", "since": "2024-01-01T00:00:00Z", "until": "2024-12-31T23:59:59Z" }' \
-  https://api.sms-gate.app/3rdparty/v1/messages/inbox/export
+  -d '{
+    "since": "2024-06-01T00:00:00Z",
+    "until": "2024-06-30T23:59:59Z",
+    "webhookDelivery": "Disabled"
+  }' \
+  https://api.sms-gate.app/3rdparty/v1/inbox/refresh
 ```
 
 ## 🔧 How to Use
@@ -114,23 +115,28 @@ curl -u <username>:<password> \
     "http://<device_local_ip>:8080/inbox?type=SMS&limit=50"
 ```
 
-### Option 2: Export via Webhooks (POST /messages/inbox/export)
+### Option 2: Export via Webhooks (POST /inbox/refresh)
 
 Use this to process historical messages through your existing webhook handler:
 
-1. Register the `sms:received` webhook as described in the [Webhooks](../features/webhooks.md) guide if you haven't done so already.
-2. Send a request with `deviceId` and period to the `POST /messages/inbox/export` endpoint:
-    ```bash title="Export messages"
+1. Register the webhook event (e.g. `sms:received` or `sms:batch:received`) as described in the [Webhooks](../features/webhooks.md) guide if you haven't done so already.
+2. Send a request with the desired `webhookDelivery` mode:
+    ```bash title="Individual export"
     curl -u <username>:<password> \
       -H "Content-Type: application/json" \
-      -d '{ "deviceId": "<device-id>", "since": "2024-01-01T00:00:00Z", "until": "2024-12-31T23:59:59Z" }' \
-      https://api.sms-gate.app/3rdparty/v1/messages/inbox/export
+      -d '{
+        "since": "2024-01-01T00:00:00Z",
+        "until": "2024-12-31T23:59:59Z",
+        "webhookDelivery": "Individual"
+      }' \
+      https://api.sms-gate.app/3rdparty/v1/inbox/refresh
     ```
-3. After receiving the request, the device will send `sms:received` webhooks for each message in the inbox for the specified period.
+3. After receiving the request, the device will send webhooks with messages from the specified period.
 
 ## 📝 Notes
 
-* The webhook will be sent for each message independently, so the order of messages is not guaranteed.
+* For `Individual` mode, webhooks are sent for each message independently, so the order of messages is not guaranteed.
+* For `Batch` mode, messages are delivered in chronological order in batch payloads of up to 100 messages.
 * It is recommended to split long periods into shorter ones to avoid excessive load on your webhook receiver.
 * The export webhooks retry policy is the same as described in the [Webhooks](../features/webhooks.md) guide.
 * The ID for incoming messages is generated based on the content of the message and is not guaranteed to be unique.
@@ -138,6 +144,6 @@ Use this to process historical messages through your existing webhook handler:
 
 ## 📚 See Also
 
-- [Webhooks Documentation](../features/webhooks.md) - For real-time message notifications
+- [Webhooks Documentation](../features/webhooks.md) - For real-time message notifications and batch webhooks
 - [API Integration Guide](../integration/api.md) - For detailed API specifications
 - [Local Server Mode](../getting-started/local-server.md) - For inbox API in local mode

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -86,6 +86,56 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
 
 </div>
 
+## 📦 Batch Webhooks
+
+Batch webhooks deliver multiple messages in a single payload, triggered during inbox refresh operations. They use the same fields as individual events, wrapped in a `messages` array. Messages are ordered chronologically inside the batch.
+
+Batch webhooks are available for:
+
+| Event                       | Description                         |
+| --------------------------- | ----------------------------------- |
+| **sms:batch:received**      | Batch of received SMS messages      |
+| **sms:batch:data-received** | Batch of received data SMS messages |
+| **mms:batch:received**      | Batch of received MMS messages      |
+| **mms:batch:downloaded**    | Batch of downloaded MMS messages    |
+
+!!! tip "Batch vs Individual"
+    Use batch webhooks when exporting historical messages to reduce HTTP overhead and ensure chronological ordering. Individual webhooks are better for real-time notifications of new messages.
+
+!!! note "Batch Size"
+    Each batch payload contains at most **100 messages**. If the export contains more messages, they will be split into multiple sequential batch webhooks.
+
+### Batch Payload Example
+
+```json title="sms:batch:received payload"
+{
+  "deviceId": "ffffffffceb0b1db0000018e937c815b",
+  "event": "sms:batch:received",
+  "id": "abc123",
+  "webhookId": "xyz789",
+  "payload": {
+    "messages": [
+      {
+        "messageId": "a1b2c3",
+        "message": "First message",
+        "sender": "+1234567890",
+        "recipient": "+0987654321",
+        "simNumber": 1,
+        "receivedAt": "2024-06-22T15:46:11.000+07:00"
+      },
+      {
+        "messageId": "d4e5f6",
+        "message": "Second message",
+        "sender": "+1234567890",
+        "recipient": "+0987654321",
+        "simNumber": 1,
+        "receivedAt": "2024-06-22T15:47:22.000+07:00"
+      }
+    ]
+  }
+}
+```
+
 !!! note "`sender` and `recipient` May Be `null`"
     For inbound events (`sms:received`, `sms:data-received`, `mms:received`, `mms:downloaded`), `recipient` represents the device's own phone number and can be `null` if the app lacks `READ_PHONE_STATE` permission or the carrier doesn't provide the number. For outbound events like `sms:delivered`, `recipient` is always the recipient's number. `sender` (the device's own number) may similarly be `null` for outbound events if the device number is unavailable.
 

--- a/docs/integration/authentication.md
+++ b/docs/integration/authentication.md
@@ -173,7 +173,14 @@ All scopes follow the pattern: `resource:action`
 | `messages:read`   | Permission to read individual message details | Read         |
 | `messages:list`   | Permission to list and view messages          | Read         |
 | `messages:cancel` | Permission to cancel pending messages         | Delete       |
-| `messages:export` | Permission to export inbox messages          | Read         |
+
+#### Inbox Scopes
+
+| Scope           | Description                                                   | Access Level |
+| --------------- | ------------------------------------------------------------- | ------------ |
+| `inbox:list`    | Permission to list and view inbox messages                    | Read         |
+| `inbox:read`    | Permission to read individual message details and attachments | Read         |
+| `inbox:refresh` | Permission to refresh inbox messages                          | Read         |
 
 #### Devices Scopes
 
@@ -217,13 +224,20 @@ All scopes follow the pattern: `resource:action`
 
 #### Messages API
 
-| Endpoint                             | Method | Required Scope    | Description            |
-| ------------------------------------ | ------ | ----------------- | ---------------------- |
-| `/3rdparty/v1/messages`              | GET    | `messages:list`   | List messages          |
-| `/3rdparty/v1/messages`              | POST   | `messages:send`   | Send a new message     |
-| `/3rdparty/v1/messages/:id`          | GET    | `messages:read`   | Get message details    |
-| `/3rdparty/v1/messages/:id`          | DELETE | `messages:cancel` | Cancel pending message |
-| `/3rdparty/v1/messages/inbox/export` | POST   | `messages:export` | Export messages        |
+| Endpoint                    | Method | Required Scope    | Description            |
+| --------------------------- | ------ | ----------------- | ---------------------- |
+| `/3rdparty/v1/messages`     | GET    | `messages:list`   | List messages          |
+| `/3rdparty/v1/messages`     | POST   | `messages:send`   | Send a new message     |
+| `/3rdparty/v1/messages/:id` | GET    | `messages:read`   | Get message details    |
+| `/3rdparty/v1/messages/:id` | DELETE | `messages:cancel` | Cancel pending message |
+
+#### Inbox API
+
+| Endpoint                                     | Method | Required Scope  | Description    |
+| -------------------------------------------- | ------ | --------------- | -------------- |
+| `/3rdparty/v1/inbox`                         | GET    | `inbox:list`    | List inbox     |
+| `/3rdparty/v1/inbox/refresh`                 | POST   | `inbox:refresh` | Refresh inbox  |
+| `/3rdparty/v1/inbox/:id/attachments/:partId` | GET    | `inbox:read`    | Get attachment |
 
 #### Devices API
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -123,7 +123,9 @@ Scopes define permissions. Use the principle of least privilege:
 | `messages:send` | Send SMS messages |
 | `messages:read` | Read individual message details |
 | `messages:list` | List and view messages |
-| `messages:export` | Export inbox messages |
+| `inbox:list`    | List incoming messages with filters |
+| `inbox:read`    | Read individual message details and attachments              |
+| `inbox:refresh` | Refresh inbox messages              |
 | `devices:list` | List registered devices |
 | `devices:delete` | Remove devices |
 | `webhooks:list` | List webhook configurations |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated inbox guidance to use the refresh endpoint for processing messages from a specified period via webhooks and removed the export endpoint.
  * Added refresh delivery modes for individual, batch, or disabled webhooks, with guidance on ordering and batch sizes.
  * Documented batch webhook event types, chronological ordering, 100-message payload limits, sequential splitting, and example payloads.
  * Updated authentication guidance with `inbox:list`, `inbox:read`, and `inbox:refresh` scopes, including access to message details and attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->