### PR TITLE
[webhooks] mms downloaded event

### DIFF
--- a/docs/faq/webhooks.md
+++ b/docs/faq/webhooks.md
@@ -180,7 +180,10 @@ If your MMS webhook isn't firing, check these potential issues:
 
 ## :material-attachment: Can I receive MMS attachments in webhooks?
 
-The webhook system provides MMS metadata but does **not** include actual attachment content.
+It depends on the event type:
+
+- **`mms:received`** (arrival notification) — metadata only, no attachment content.
+- **`mms:downloaded`** (full download) — includes base64-encoded attachment data in the `attachments` array, accessible via the `data` field (may be `null` if content is unavailable).
 
 ## :material-chat-question: Still Having Issues?
 

--- a/docs/features/mms.md
+++ b/docs/features/mms.md
@@ -4,7 +4,10 @@ The SMSGate application supports receiving MMS messages through webhook notifica
 
 ## 📋 Overview
 
-MMS (Multimedia Messaging Service) support enables your SMSGate to receive and process multimedia messages containing images, videos, audio files, and other attachments. When an MMS message is received, the application triggers a webhook notification with detailed metadata about the message.
+MMS (Multimedia Messaging Service) support enables your SMSGate to receive and process multimedia messages containing images, videos, audio files, and other attachments. The application provides two distinct MMS webhook events at different stages of message delivery:
+
+- **`mms:received`** — Fires when the MMS **notification** (WAP push) arrives, before the message is downloaded. Provides metadata only (transaction ID, subject, size, content class).
+- **`mms:downloaded`** — Fires when the MMS has been **fully downloaded** to the device. Includes the message body, subject, and attachments with base64-encoded content.
 
 !!! note "Receive-Only Support"
     The application currently supports **receiving MMS messages only**. Sending MMS messages is not available.
@@ -17,9 +20,11 @@ The following permissions must be granted to the SMSGate application to enable M
 - **RECEIVE_MMS**: **Required for MMS functionality** - enables the app to receive multimedia messages
 - **READ_PHONE_STATE**: Optional, for SIM card information
 
-## 📊 MMS Webhook Payload
+## 📊 MMS Webhook Events
 
-When an MMS message is received, your webhook will receive a POST request with the following JSON structure:
+### `mms:received` — Arrival Notification
+
+Triggered when the device receives a WAP push notification for an incoming MMS. This event fires **before** the message content is downloaded and contains metadata only.
 
 ```json
 {
@@ -41,15 +46,49 @@ When an MMS message is received, your webhook will receive a POST request with t
 }
 ```
 
-!!! warning "No Message Content"
-    The MMS webhook payload contains **metadata only** - no message text or attachment content is included.
+Field descriptions can be found in the [Webhook Supported Events](./webhooks.md#supported-events) section.
 
-The description of each field can be found in the [Webhook Supported Events](./webhooks.md#supported-events) section.
+### `mms:downloaded` — Full Content
+
+Triggered when the MMS content has been fully downloaded to the device content provider. This event fires **after** `mms:received` and includes the message body and attachments.
+
+```json
+{
+  "deviceId": "ffffffffceb0b1db0000018e937c815b",
+  "event": "mms:downloaded",
+  "id": "Ey6ECgOkVVFjz3CL48B8C",
+  "payload": {
+    "messageId": "mms_12345abcde",
+    "sender": "+1234567891",
+    "recipient": "+1234567890",
+    "simNumber": 1,
+    "body": "Hello! Here is the photo.",
+    "subject": "Photo attachment",
+    "attachments": [
+      {
+        "partId": 1,
+        "contentType": "image/jpeg",
+        "name": "photo.jpg",
+        "size": 125684,
+        "data": "/9j/4AAQ..."
+      }
+    ],
+    "receivedAt": "2025-08-23T05:15:35.000+07:00"
+  },
+  "webhookId": "<unique-id>"
+}
+```
+
+Field descriptions can be found in the [Webhook Supported Events](./webhooks.md#supported-events) section.
+
+!!! tip "Attachment Data"
+    The `data` field in each attachment contains the raw content encoded in Base64 when available and may be `null` if the content is unavailable. This enables programmatic processing — for example, decoding and saving images, or forwarding attachments to other services.
 
 ## 🚫 Limitations
 
 - **Receive-Only**: MMS messages cannot be sent through the API
-- **No Message Content**: Webhooks provide metadata only - no message text or attachment content is included
+- **`mms:received` Metadata Only**: The arrival notification provides metadata only — no message text or attachment content is included
+- **`mms:downloaded` Attachment Size**: Large attachments may impact webhook payload size and delivery performance. The attachment `size` and `data` fields may be `null` if the content is unavailable
 - **Carrier Dependencies**: Functionality varies by mobile carrier and network conditions
 
 ## 📚 See Also

--- a/docs/features/webhooks.md
+++ b/docs/features/webhooks.md
@@ -33,6 +33,21 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
     - `simNumber`: SIM index (nullable)
     - `receivedAt`: Local timestamp
 
+- :material-file-download: **mms:downloaded**
+    - `messageId`: Content-based ID
+    - `body`: Aggregated text content of the MMS (nullable)
+    - `subject`: Message subject line (nullable)
+    - `attachments`: Array of `{ partId, contentType, name, size, data }`
+        - `partId`: Content provider part ID
+        - `contentType`: MIME type (e.g. `image/jpeg`)
+        - `name`: Filename (nullable)
+        - `size`: Size in bytes (nullable)
+        - `data`: Base64-encoded attachment content (nullable)
+    - `sender` ⭐: Sender's phone number
+    - `recipient` 📍: Device's phone number that received the message (may be `null` if unavailable)
+    - `simNumber`: SIM index (nullable)
+    - `receivedAt`: Local timestamp
+
 - :outbox_tray: **sms:sent**
     - `messageId`: Unique ID
     - `sender` ⭐: Device's phone number
@@ -72,7 +87,7 @@ Webhooks offer a powerful mechanism to receive real-time notifications of events
 </div>
 
 !!! note "`sender` and `recipient` May Be `null`"
-    For inbound events (`sms:received`, `sms:data-received`, `mms:received`), `recipient` represents the device's own phone number and can be `null` if the app lacks `READ_PHONE_STATE` permission or the carrier doesn't provide the number. For outbound events like `sms:delivered`, `recipient` is always the recipient's number. `sender` (the device's own number) may similarly be `null` for outbound events if the device number is unavailable.
+    For inbound events (`sms:received`, `sms:data-received`, `mms:received`, `mms:downloaded`), `recipient` represents the device's own phone number and can be `null` if the app lacks `READ_PHONE_STATE` permission or the carrier doesn't provide the number. For outbound events like `sms:delivered`, `recipient` is always the recipient's number. `sender` (the device's own number) may similarly be `null` for outbound events if the device number is unavailable.
 
 ## Prerequisites ✅
 
@@ -172,6 +187,7 @@ In Cloud and Private modes, please allow some time for the webhooks list to sync
 - `sms:received`: Send an SMS to the device.
 - `sms:data-received`: Send a data SMS to port 53739.
 - `mms:received`: Send an MMS message to the device.
+- `mms:downloaded`: Wait for the MMS to fully download (fires automatically after `mms:received` when download completes).
 - `sms:sent`/`delivered`/`failed`: Send an SMS *from* the app to trigger these events.
 - `sms:cancelled`: Send an SMS via the cloud/private API, then cancel it via `DELETE /3rdparty/v1/messages/{id}` while the message is still pending.
 - `system:ping`: Enable the ping feature in the app’s **Settings > Ping**.
@@ -233,6 +249,34 @@ Your server will receive a POST request with a payload like:
         "size": 125684,
         "contentClass": "IMAGE_BASIC",
         "receivedAt": "2025-08-23T05:15:30.000+07:00"
+      },
+      "webhookId": "LreFUt-Z3sSq0JufY9uWB"
+    }
+    ```
+
+=== "mms:downloaded"
+    ```json
+    {
+      "deviceId": "ffffffffceb0b1db0000018e937c815b",
+      "event": "mms:downloaded",
+      "id": "Ey6ECgOkVVFjz3CL48B8C",
+      "payload": {
+        "messageId": "mms_12345abcde",
+        "sender": "6505551212",
+        "recipient": "+1234567890",
+        "simNumber": 1,
+        "body": "Hello! Here is the photo.",
+        "subject": "Photo attachment",
+        "attachments": [
+          {
+            "partId": 1,
+            "contentType": "image/jpeg",
+            "name": "photo.jpg",
+            "size": 125684,
+            "data": "/9j/4AAQ..."
+          }
+        ],
+        "receivedAt": "2025-08-23T05:15:35.000+07:00"
       },
       "webhookId": "LreFUt-Z3sSq0JufY9uWB"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MMS webhooks guidance with a two-stage model: `mms:received` delivers metadata only, while `mms:downloaded` delivers the full message body and attachments.
  * Clarified that attachment `data` is Base64-encoded and may be null/unavailable depending on the event.
  * Refreshed webhook docs to add `mms:downloaded`, including an example payload, updated supported-event details, and revised testing instructions plus payload-size/performance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->